### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+editra (0.7.20+dfsg.1-4) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 00:16:21 +0100
+
 editra (0.7.20+dfsg.1-3) unstable; urgency=medium
 
   * Now using wxpython3.0, thanks to Olly Betts by patch and help (Closes:

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper (>= 9),
 Standards-Version: 3.9.5
 X-Python-Version: >= 2.6
 Homepage: http://editra.org
-Vcs-Git: git://github.com/mogaal/editra
+Vcs-Git: https://github.com/mogaal/editra
 Vcs-Browser: https://github.com/mogaal/editra
 
 Package: editra


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
